### PR TITLE
Parse completed tasks in work report

### DIFF
--- a/src/main/java/bc/bob/chores/WorkReport.java
+++ b/src/main/java/bc/bob/chores/WorkReport.java
@@ -5,10 +5,43 @@ import javax.swing.JTextArea;
 public class WorkReport {
 
     String prepareReport(final Boolean enabled, final String originalReportText) {
-        String updatedReportText = "";
-        
-        
-        return updatedReportText;
+        if (!Boolean.TRUE.equals(enabled)) {
+            if (originalReportText == null) {
+                return "";
+            }
+            return originalReportText;
+        }
+
+        if (originalReportText == null) {
+            return "";
+        }
+
+        final String taskPrefix = "You completed a task:";
+        final String[] lines = originalReportText.split("\\r?\\n");
+        final StringBuilder builder = new StringBuilder();
+        boolean waitingForTaskDescription = false;
+
+        for (int index = 0; index < lines.length; index++) {
+            final String trimmedLine = lines[index].trim();
+
+            if (waitingForTaskDescription) {
+                if (!trimmedLine.isEmpty()) {
+                    if (builder.length() > 0) {
+                        builder.append('\n');
+                    }
+                    builder.append("- ");
+                    builder.append(trimmedLine);
+                    waitingForTaskDescription = false;
+                }
+                continue;
+            }
+
+            if (taskPrefix.equals(trimmedLine)) {
+                waitingForTaskDescription = true;
+            }
+        }
+
+        return builder.toString();
     }
-    
+
 }

--- a/src/test/java/bc/bob/chores/WorkReportTest.java
+++ b/src/test/java/bc/bob/chores/WorkReportTest.java
@@ -1,0 +1,52 @@
+package bc.bob.chores;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class WorkReportTest {
+
+    @Test
+    public void prepareReportExtractsCompletedTasks() {
+        // Initialization.
+        final WorkReport workReport = new WorkReport();
+        final Boolean enabled = Boolean.TRUE;
+        final String originalReportText = "Activity:\n"
+                + "Sep 24 ‧ Yesterday ‧ Wednesday\n\n"
+                + "    Bob\n\n"
+                + "You completed a task:\n"
+                + "Assign task\n"
+                + "11:47 PM\n"
+                + "Data\n"
+                + "Bob\n"
+                + "You completed a task:\n"
+                + "Start discussion with Dragos\n"
+                + "11:37 PM\n"
+                + "MRO\n"
+                + "Bob\n"
+                + "You completed a task:\n"
+                + "Assign task to Vaibhav\n"
+                + "11:33 PM\n"
+                + "Competitors\n"
+                + "Bob\n"
+                + "You completed a task:\n"
+                + "Assign task to Vaibhav\n"
+                + "11:33 PM\n"
+                + "Competitors\n"
+                + "Bob\n"
+                + "You completed a task:\n"
+                + "Send report to Anthony\n\n";
+        final String expectedReport = "- Assign task\n"
+                + "- Start discussion with Dragos\n"
+                + "- Assign task to Vaibhav\n"
+                + "- Assign task to Vaibhav\n"
+                + "- Send report to Anthony";
+
+        // Execution.
+        final String updatedReport = workReport.prepareReport(enabled, originalReportText);
+
+        // Assertion.
+        assertThat(updatedReport, is(expectedReport));
+    }
+}


### PR DESCRIPTION
## Summary
- extract task descriptions that follow the "You completed a task:" marker when preparing reports
- add a unit test that exercises the report-cleanup workflow on the provided sample text

## Testing
- mvn -q test *(fails: repository https://repo.maven.apache.org/maven2 unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d4aad0af60832babd7b94e556dd881